### PR TITLE
Next

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,7 +275,7 @@ dependencies = [
 
 [[package]]
 name = "srmilter"
-version = "6.0.0"
+version = "7.0.0"
 dependencies = [
  "clap",
  "lazy-regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,12 +68,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
-name = "build-env"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1522ac6ee801a11bf9ef3f80403f4ede6eb41291fac3dde3de09989679305f25"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,43 +126,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
-name = "cstr-argument"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bd9c8e659a473bce955ae5c35b116af38af11a7acb0b480e01f3ed348aeb40"
-dependencies = [
- "cfg-if",
- "memchr",
-]
-
-[[package]]
-name = "foreign-types"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
-dependencies = [
- "foreign-types-macros",
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-macros"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
-
-[[package]]
 name = "hashify"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,24 +178,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
-name = "libsystemd-sys"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976306de183e6046819ef6505888d00996214766a3f4660a2ed5761c84a20aed"
-dependencies = [
- "build-env",
- "cfg-if",
- "libc",
- "pkg-config",
-]
-
-[[package]]
-name = "log"
-version = "0.4.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
 name = "mail-parser"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,12 +215,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "proc-macro2"
@@ -349,7 +282,6 @@ dependencies = [
  "mail-parser",
  "nix",
  "socket2",
- "systemd",
 ]
 
 [[package]]
@@ -370,31 +302,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "systemd"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01e9d1976a15b86245def55d20d52b5818e1a1e81aa030b6a608d3ce57709423"
-dependencies = [
- "cstr-argument",
- "foreign-types",
- "libc",
- "libsystemd-sys",
- "log",
- "memchr",
- "utf8-cstr",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "utf8-cstr"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55bcbb425141152b10d5693095950b51c3745d019363fc2929ffd8f61449b628"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,12 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,19 +62,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "auto_encoder"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6364e11e0270035ec392151a54f1476e6b3612ef9f4fe09d35e72a8cebcb65"
-dependencies = [
- "chardetng",
- "encoding_rs",
- "percent-encoding",
- "phf 0.11.3",
- "phf_codegen 0.11.3",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,17 +84,6 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
-name = "chardetng"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b8f0b65b7b08ae3c8187e8d77174de20cb6777864c6b832d8ad365999cf1ea"
-dependencies = [
- "cfg-if",
- "encoding_rs",
- "memchr",
-]
 
 [[package]]
 name = "clap"
@@ -162,29 +132,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
-name = "cssparser"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
-dependencies = [
- "cssparser-macros",
- "dtoa-short",
- "itoa",
- "phf 0.13.1",
- "smallvec",
-]
-
-[[package]]
-name = "cssparser-macros"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
 name = "cstr-argument"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,95 +140,6 @@ dependencies = [
  "cfg-if",
  "memchr",
 ]
-
-[[package]]
-name = "derive_more"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn",
-]
-
-[[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "dtoa"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
-
-[[package]]
-name = "dtoa-short"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
-dependencies = [
- "dtoa",
-]
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "equivalent"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
-name = "fast_html2md"
-version = "0.0.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af3a0122fee1bcf6bb9f3d73782e911cce69d95b76a5e29e930af92cd4a8e4e3"
-dependencies = [
- "auto_encoder",
- "futures-util",
- "lazy_static",
- "lol_html",
- "percent-encoding",
- "regex",
- "url",
-]
-
-[[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "foldhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -311,49 +169,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
-name = "form_urlencoded"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
-dependencies = [
- "percent-encoding",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-task"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
-
-[[package]]
-name = "futures-util"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
-dependencies = [
- "futures-core",
- "futures-task",
- "pin-project-lite",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
-]
-
-[[package]]
 name = "hashify"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,118 +186,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "icu_collections"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
-dependencies = [
- "displaydoc",
- "potential_utf",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locale_core"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
-dependencies = [
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
-
-[[package]]
-name = "icu_properties"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
-dependencies = [
- "icu_collections",
- "icu_locale_core",
- "icu_properties_data",
- "icu_provider",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
-
-[[package]]
-name = "icu_provider"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
-dependencies = [
- "displaydoc",
- "icu_locale_core",
- "writeable",
- "yoke",
- "zerofrom",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "idna"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
-dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "idna_adapter"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itoa"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "lazy-regex"
@@ -508,12 +215,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,35 +233,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "litemap"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
-
-[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
-name = "lol_html"
-version = "2.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ff94cb6aef6ee52afd2c69331e9109906d855e82bd241f3110dfdf6185899ab"
-dependencies = [
- "bitflags",
- "cfg-if",
- "cssparser",
- "encoding_rs",
- "foldhash",
- "hashbrown",
- "memchr",
- "mime",
- "precomputed-hash",
- "selectors",
- "thiserror",
-]
 
 [[package]]
 name = "mail-parser"
@@ -576,18 +252,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
@@ -614,142 +278,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "percent-encoding"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_macros 0.11.3",
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
-dependencies = [
- "phf_macros 0.13.1",
- "phf_shared 0.13.1",
- "serde",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
-dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared 0.11.3",
- "rand",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
-dependencies = [
- "fastrand",
- "phf_shared 0.13.1",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
-dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "potential_utf"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
-dependencies = [
- "zerovec",
-]
-
-[[package]]
-name = "precomputed-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
@@ -768,21 +300,6 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "regex"
@@ -814,96 +331,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "rustc-hash"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
-name = "selectors"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feef350c36147532e1b79ea5c1f3791373e61cbd9a6a2615413b3807bb164fb7"
-dependencies = [
- "bitflags",
- "cssparser",
- "derive_more",
- "log",
- "new_debug_unreachable",
- "phf 0.13.1",
- "phf_codegen 0.13.1",
- "precomputed-hash",
- "rustc-hash",
- "servo_arc",
- "smallvec",
-]
-
-[[package]]
-name = "semver"
-version = "1.0.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
-
-[[package]]
-name = "serde"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "serde_core"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "servo_arc"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
-dependencies = [
- "stable_deref_trait",
-]
-
-[[package]]
-name = "siphasher"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
-
-[[package]]
-name = "smallvec"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
 name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,19 +345,12 @@ name = "srmilter"
 version = "6.0.0"
 dependencies = [
  "clap",
- "fast_html2md",
  "lazy-regex",
  "mail-parser",
  "nix",
  "socket2",
  "systemd",
 ]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"
@@ -950,17 +370,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "systemd"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -976,64 +385,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tinystr"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
-dependencies = [
- "displaydoc",
- "zerovec",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "url"
-version = "2.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
- "serde",
-]
-
-[[package]]
 name = "utf8-cstr"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55bcbb425141152b10d5693095950b51c3745d019363fc2929ffd8f61449b628"
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1054,87 +415,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "writeable"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
-
-[[package]]
-name = "yoke"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
-dependencies = [
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "zerofrom"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "zerotrie"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -28,15 +28,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "cfg-if"
@@ -81,9 +81,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -91,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -103,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -115,22 +115,35 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashify"
-version = "0.2.7"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "149e3ea90eb5a26ad354cfe3cb7f7401b9329032d0235f2687d03a35f30e5d4c"
+checksum = "dd1246c0e5493286aeb2dde35b1f4eb9c4ce00e628641210a5e553fc001a1f26"
 dependencies = [
+ "indexmap",
  "proc-macro2",
  "quote",
  "syn",
@@ -141,6 +154,16 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -173,15 +196,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "mail-parser"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82a3d6522697593ba4c683e0a6ee5a40fee93bc1a525e3cc6eeb3da11fd8897"
+checksum = "d8a2420e9ce11c2b0583ca97ddff7ab2398c8a613154e9b72e3bafdbf767f1d7"
 dependencies = [
  "hashify",
 ]
@@ -194,9 +217,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -206,9 +229,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srmilter"
-version = "6.0.0"
+version = "7.0.0"
 edition = "2024"
 authors = ["Donald Buczek <buczek@molgen.mpg.de>"]
 description = "A Rust library for building mail filter (milter) daemons that integrate with Postfix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,16 +10,11 @@ keywords = ["milter", "postfix", "email", "mail-filter", "spam"]
 categories = ["email", "network-programming"]
 license = "EUPL-1.2"
 
-[features]
-default = ["systemd"]
-systemd = ["dep:systemd"]
-
 [dependencies]
 clap = { version = "4.5.40", features = ["derive"] }
 mail-parser = "0.11.0"
 nix = { version = "0.31.2", features = ["signal"] }
 socket2 = { version = "0.6.0", features = ["all"] }
-systemd = { version = "0.10.0", optional = true }
 
 [dev-dependencies]
 lazy-regex = "3.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ systemd = ["dep:systemd"]
 
 [dependencies]
 clap = { version = "4.5.40", features = ["derive"] }
-fast_html2md = "0.0.58"
 mail-parser = "0.11.0"
 nix = { version = "0.31.2", features = ["signal"] }
 socket2 = { version = "0.6.0", features = ["all"] }

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ srmilter implements the milter protocol to receive emails from Postfix, parse th
 - Email parsing via `mail-parser` crate
 - Multithreading
 - Spamhaus ZEN DNSBL lookup utilities
-- systemd socket activation support (optional)
+- systemd socket activation support
 - Built-in CLI
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ srmilter implements the milter protocol to receive emails from Postfix, parse th
 
 ### Example
 
-```rust
+```rust,no_run
 use srmilter::{ClassifyResult, Config, EmailClassifier, MailInfo};
 
 struct Ctx {
@@ -132,7 +132,7 @@ systemctl reload mymilter
 
 Add to your Postfix `main.cf`:
 
-```
+```text
 smtpd_milters = inet:127.0.0.1:7044
 ```
 

--- a/README.md
+++ b/README.md
@@ -141,4 +141,4 @@ smtpd_milters = inet:127.0.0.1:7044
 Copyright © 2025 Donald Buczek <buczek@molgen.mpg.de>
 
 Licensed under the European Union Public Licence (EUPL), Version 1.2.
-See the [LICENSE](LICENSE) file for details.
+See the [LICENSE](https://github.com/mpimg/srmilter/blob/main/LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ fn classify(_ctx: &Ctx, mail_info: &MailInfo) -> ClassifyResult {
 
 ## CLI Commands
 
-The built-in CLI provides three subcommands:
+The built-in CLI provides two subcommands:
 
 ```bash
 # Run the milter daemon (default: 0.0.0.0:7044)

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ myfilter test <file.eml> [sender] [recipients...]
 ### Concurrency Options
 
 - **Default**: Up to 64 threads
-- `--threads N`: Use up to N threads (0 = single-threaded)
+- `--threads N`: Use up to N threads
 
 ## systemd Deployment with Zero-Downtime Reloads
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Rust library for building mail filter (milter) daemons that integrate with Pos
 
 ## Overview
 
-srmilter implements the milter protocol to receive emails from Postfix, parse them, and return classification decisions (accept, reject, or quarantine). It provides a simple API for writing custom email classifiers.
+srmilter implements the milter protocol to receive emails from Postfix, parse them, and return classification decisions (accept, reject, reject with custom message, quarantine, or discard). It provides a simple API for writing custom email classifiers.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ myfilter test <file.eml> [sender] [recipients...]
 
 ### Concurrency Options
 
-- **Default**: Single-threaded, sequential processing
-- `--threads N`: Use up to N threads
+- **Default**: Up to 64 threads
+- `--threads N`: Use up to N threads (0 = single-threaded)
 
 ## systemd Deployment with Zero-Downtime Reloads
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -46,7 +46,7 @@ struct DumpArgs {
 pub(crate) struct DaemonArgs {
     #[arg(default_value = "0.0.0.0:7044")]
     pub address: String,
-    #[arg(long = "threads", default_value_t = 64)]
+    #[arg(long = "threads", default_value_t = 64, value_parser = clap::value_parser!(u16).range(1..))]
     pub threads_max: u16,
     #[arg(long = "truncate", default_value_t = usize::MAX, hide_default_value = true, value_name = "BYTES")]
     pub truncate: usize,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,6 @@
 use crate::daemon::daemon;
 use crate::{Config, MailInfoStorage, classify_mail};
 use clap::Parser;
-use mail_parser::{MessageParser, MimeHeaders};
 use std::error::Error;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -21,54 +20,6 @@ fn cmd_test(
     };
     classify_mail(config, &storage);
     Ok(())
-}
-
-fn cmd_dump(dump_args: &DumpArgs) -> Result<(), Box<dyn Error>> {
-    eprintln!("WARNING: dump command is deprecated!");
-    let (dump_header, dump_body) = match (dump_args.header, dump_args.body) {
-        (false, false) => (true, true),
-        (dump_header, dump_body) => (dump_header, dump_body),
-    };
-    let dump_html = dump_args.dump_html;
-    let filename = &dump_args.filename;
-    let mail_buffer = fs::read(filename)?;
-    let r = MessageParser::default().parse(&mail_buffer);
-    match r {
-        Some(msg) => {
-            if dump_header && let Some(part) = msg.parts.first() {
-                for h in &part.headers {
-                    println!("{}: {:?}", h.name, &h.value);
-                }
-            }
-            if dump_body {
-                for part in msg.parts {
-                    let (content_type, content_subtype) = {
-                        match part.content_type() {
-                            Some(c) => (c.ctype(), c.subtype().unwrap_or("")),
-                            None => ("???", "???"),
-                        }
-                    };
-                    println!(
-                        "==================================== {}/{}",
-                        content_type, content_subtype
-                    );
-                    if part.is_content_type("text", "plain") {
-                        if let Some(text) = part.text_contents() {
-                            println!("{}", text.trim());
-                        }
-                    } else if dump_html
-                        && part.is_content_type("text", "html")
-                        && let Some(text) = part.text_contents()
-                    {
-                        let md = html2md::rewrite_html(text, false);
-                        println!("{}", md);
-                    }
-                }
-            }
-            Ok(())
-        }
-        None => Err("parse error".into()),
-    }
 }
 
 #[derive(clap::Parser)]
@@ -95,13 +46,6 @@ struct DumpArgs {
 pub(crate) struct DaemonArgs {
     #[arg(default_value = "0.0.0.0:7044")]
     pub address: String,
-    #[arg(
-        long = "fork",
-        default_value_t = 0,
-        hide_default_value = true,
-        help = "(Deprecated!)"
-    )]
-    pub fork_max: u16,
     #[arg(long = "threads", default_value_t = 0, hide_default_value = true)]
     pub threads_max: u16,
     #[arg(long = "truncate", default_value_t = usize::MAX, hide_default_value = true, value_name = "BYTES")]
@@ -116,8 +60,6 @@ enum Command {
         recipients: Option<Vec<String>>,
     },
     Daemon(DaemonArgs),
-    #[command(about = "(Deprecated!)")]
-    Dump(DumpArgs),
 }
 
 /// Main entry point for the milter CLI.
@@ -127,7 +69,6 @@ enum Command {
 /// - `daemon [address] [--threads N] [--truncate N]` - Run the milter server
 ///   (default address: `0.0.0.0:7044`)
 /// - `test <file> [sender] [recipients...]` - Test the classifier against an `.eml` file
-/// - `dump <file> [-H] [-b] [--html]` - Dump parsed email headers and/or body
 ///
 /// # Example
 ///
@@ -153,21 +94,6 @@ pub fn cli(config: &Config) -> Result<(), Box<dyn Error>> {
             sender.unwrap_or_default(),
             recipients.unwrap_or_default(),
         ),
-        Command::Daemon(args) => {
-            if args.fork_max > 0 {
-                eprintln!("WARNING: fork mode is deprecated!");
-            }
-            if args.fork_max > 0 && args.threads_max > 0 {
-                return Err("--fork and --threads are mutually exclusive".into());
-            }
-            if args.fork_max > 0 && !config.fork_mode_enabled {
-                return Err(
-                    "--fork mode not available: Needs to be opted in by main milter program."
-                        .into(),
-                );
-            }
-            daemon(config, &args)
-        }
-        Command::Dump(dump_args) => cmd_dump(&dump_args),
+        Command::Daemon(args) => daemon(config, &args),
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -46,7 +46,7 @@ struct DumpArgs {
 pub(crate) struct DaemonArgs {
     #[arg(default_value = "0.0.0.0:7044")]
     pub address: String,
-    #[arg(long = "threads", default_value_t = 0, hide_default_value = true)]
+    #[arg(long = "threads", default_value_t = 64)]
     pub threads_max: u16,
     #[arg(long = "truncate", default_value_t = usize::MAX, hide_default_value = true, value_name = "BYTES")]
     pub truncate: usize,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -5,7 +5,7 @@ use crate::{ClassifyResult, Config, MailInfoStorage, classify_mail};
 use nix::libc::c_int;
 use nix::sys::signal::{SaFlags, SigAction, SigHandler, SigSet, Signal, sigaction};
 use nix::sys::wait::{WaitPidFlag, WaitStatus, waitpid};
-use nix::unistd::{ForkResult, Pid, fork, pause};
+use nix::unistd::Pid;
 use socket2::{Domain, Protocol, Socket, Type};
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -16,7 +16,6 @@ use std::io::{BufRead, BufReader, BufWriter, Cursor, Read as _, Seek as _, Write
 use std::net::{SocketAddr, TcpStream};
 #[cfg(feature = "systemd")]
 use std::os::fd::FromRawFd as _;
-use std::process::exit;
 use std::sync::atomic::{AtomicBool, AtomicU16, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
@@ -368,10 +367,6 @@ fn get_listen_socket(args: &DaemonArgs) -> Result<Socket, Box<dyn Error>> {
 pub fn daemon(config: &Config, args: &DaemonArgs) -> Result<(), Box<dyn Error>> {
     let listen_socket = get_listen_socket(args)?;
 
-    if args.fork_max > 0 && args.threads_max > 0 {
-        return Err("Cannot use both fork and thread modes simultaneously".into());
-    }
-
     let thread_state: Option<Arc<(Mutex<u16>, Condvar)>> = if args.threads_max > 0 {
         Some(Arc::new((Mutex::new(0), Condvar::new())))
     } else {
@@ -380,11 +375,7 @@ pub fn daemon(config: &Config, args: &DaemonArgs) -> Result<(), Box<dyn Error>> 
 
     install_signal_handler();
     loop {
-        if args.fork_max > 0 {
-            while CHILDREN_CNT.load(Ordering::Relaxed) >= args.fork_max {
-                pause()
-            }
-        } else if let Some(ref state) = thread_state {
+        if let Some(ref state) = thread_state {
             let (lock, cvar) = state.as_ref();
             let mut count = lock.lock().unwrap();
             while *count >= args.threads_max {
@@ -393,27 +384,7 @@ pub fn daemon(config: &Config, args: &DaemonArgs) -> Result<(), Box<dyn Error>> 
         }
         match listen_socket.accept() {
             Ok((socket, _addr)) => {
-                if args.fork_max > 0 {
-                    match unsafe { fork() } {
-                        Ok(ForkResult::Parent { .. }) => {
-                            CHILDREN_CNT.fetch_add(1, Ordering::Relaxed);
-                        }
-                        Ok(ForkResult::Child) => {
-                            drop(listen_socket);
-                            let stream: TcpStream = socket.into();
-                            let reader = BufReader::new(&stream);
-                            let writer = BufWriter::new(&stream);
-                            match process_client(config, reader, writer, args.truncate) {
-                                Ok(_) => exit(0),
-                                Err(e) => {
-                                    eprintln!("{e}");
-                                    exit(1)
-                                }
-                            }
-                        }
-                        Err(e) => eprintln!("fork: {e}"),
-                    }
-                } else if args.threads_max > 0 {
+                if args.threads_max > 0 {
                     let state_clone = thread_state.as_ref().unwrap().clone();
 
                     // Increment thread count

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -14,7 +14,6 @@ use std::env::VarError;
 use std::error::Error;
 use std::io::{BufRead, BufReader, BufWriter, Cursor, Read as _, Seek as _, Write};
 use std::net::{SocketAddr, TcpStream};
-#[cfg(feature = "systemd")]
 use std::os::fd::FromRawFd as _;
 use std::sync::atomic::{AtomicBool, AtomicU16, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
@@ -344,10 +343,8 @@ fn get_listen_fd() -> Result<Option<c_int>, Box<dyn Error>> {
         Err(e) => return Err(e.into()),
         Ok(string) => return Ok(Some(string.parse()?)),
     }
-    #[cfg(feature = "systemd")]
-    match systemd::daemon::listen_fds(false).unwrap().iter().next() {
-        None => (),
-        Some(fd) => return Ok(Some(fd)),
+    if env::var_os("LISTEN_FDS").is_some() {
+        return Ok(Some(3));
     }
     Ok(None)
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -275,6 +275,18 @@ fn process_client(
                         stream_writer
                             .write_all(&writer.get_ref()[0..writer.position() as usize])?;
                     }
+                    ClassifyResult::Discard => {
+                        writer.rewind()?;
+                        writer.write_all(b"d")?; // SMFIR_DISCARD
+                        stream_writer.write_all(&((writer.position() as u32).to_be_bytes()))?;
+                        stream_writer
+                            .write_all(&writer.get_ref()[0..writer.position() as usize])?;
+                        writer.rewind()?;
+                        writer.write_all(b"a")?; // SMFIR_ACCEPT
+                        stream_writer.write_all(&((writer.position() as u32).to_be_bytes()))?;
+                        stream_writer
+                            .write_all(&writer.get_ref()[0..writer.position() as usize])?;
+                    }
                 };
                 stream_writer.flush()?;
                 storage = MailInfoStorage::default();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -367,16 +367,12 @@ fn get_listen_socket(args: &DaemonArgs) -> Result<Socket, Box<dyn Error>> {
 pub fn daemon(config: &Config, args: &DaemonArgs) -> Result<(), Box<dyn Error>> {
     let listen_socket = get_listen_socket(args)?;
 
-    let thread_state: Option<Arc<(Mutex<u16>, Condvar)>> = if args.threads_max > 0 {
-        Some(Arc::new((Mutex::new(0), Condvar::new())))
-    } else {
-        None
-    };
+    let thread_state = Arc::new((Mutex::new(0u16), Condvar::new()));
 
     install_signal_handler();
     loop {
-        if let Some(ref state) = thread_state {
-            let (lock, cvar) = state.as_ref();
+        {
+            let (lock, cvar) = thread_state.as_ref();
             let mut count = lock.lock().unwrap();
             while *count >= args.threads_max {
                 count = cvar.wait(count).unwrap();
@@ -384,39 +380,30 @@ pub fn daemon(config: &Config, args: &DaemonArgs) -> Result<(), Box<dyn Error>> 
         }
         match listen_socket.accept() {
             Ok((socket, _addr)) => {
-                if args.threads_max > 0 {
-                    let state_clone = thread_state.as_ref().unwrap().clone();
+                let state_clone = thread_state.clone();
 
-                    // Increment thread count
-                    {
-                        let (lock, _) = state_clone.as_ref();
-                        let mut count = lock.lock().unwrap();
-                        *count += 1;
-                    }
+                // Increment thread count
+                {
+                    let (lock, _) = state_clone.as_ref();
+                    let mut count = lock.lock().unwrap();
+                    *count += 1;
+                }
 
-                    let stream: TcpStream = socket.into();
-                    let thread_config = config.clone();
-                    let truncate = args.truncate;
-                    thread::spawn(move || {
-                        let reader = BufReader::new(&stream);
-                        let writer = BufWriter::new(&stream);
-                        if let Err(e) = process_client(&thread_config, reader, writer, truncate) {
-                            eprintln!("thread error: {e}");
-                        }
-                        // Decrement count and signal
-                        let (lock, cvar) = &*state_clone;
-                        let mut count = lock.lock().unwrap();
-                        *count -= 1;
-                        cvar.notify_one();
-                    });
-                } else {
-                    let stream: TcpStream = socket.into();
+                let stream: TcpStream = socket.into();
+                let thread_config = config.clone();
+                let truncate = args.truncate;
+                thread::spawn(move || {
                     let reader = BufReader::new(&stream);
                     let writer = BufWriter::new(&stream);
-                    if let Err(e) = process_client(config, reader, writer, args.truncate) {
-                        eprintln!("{e}");
+                    if let Err(e) = process_client(&thread_config, reader, writer, truncate) {
+                        eprintln!("thread error: {e}");
                     }
-                }
+                    // Decrement count and signal
+                    let (lock, cvar) = &*state_clone;
+                    let mut count = lock.lock().unwrap();
+                    *count -= 1;
+                    cvar.notify_one();
+                });
             }
             Err(e) if e.kind() == std::io::ErrorKind::Interrupted => (),
             // todo: retry on ENETDOWN, EPROTO, ENOPROTOOPT... see accept(2)
@@ -428,8 +415,8 @@ pub fn daemon(config: &Config, args: &DaemonArgs) -> Result<(), Box<dyn Error>> 
     }
 
     // Wait for active threads to complete
-    if let Some(ref state) = thread_state {
-        let (lock, cvar) = state.as_ref();
+    {
+        let (lock, cvar) = thread_state.as_ref();
         let mut count = lock.lock().unwrap();
         while *count > 0 {
             let result = cvar.wait_timeout(count, Duration::from_secs(1)).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../README.md")]
+
 use mail_parser::{HeaderName, MessageParser, MessagePart};
 use std::borrow::Cow;
 use std::collections::HashMap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -322,6 +322,13 @@ impl MailInfo<'_> {
         ClassifyResult::Quarantine
     }
 
+    /// Logs a discard message and returns [`ClassifyResult::Discard`].
+    #[must_use]
+    pub fn discard(&self, msg: &str) -> ClassifyResult {
+        self.log(&format!("{} ({})", ClassifyResult::Discard.uc(), msg));
+        ClassifyResult::Discard
+    }
+
     /// Logs `log_msg` to stderr and returns [`ClassifyResult::RejectWithMsg`]. `client_msg` is sent
     /// to the client with the fixed extended status code "550 5.7.1". It needs to be a valid SMTP
     /// error text (printable ASCII). '%' characters are allowed and don't have special meaning,
@@ -372,6 +379,8 @@ pub enum ClassifyResult {
     RejectWithMsg(Cow<'static, [u8]>),
     /// Accept but hold the email in Postfix quarantine.
     Quarantine,
+    /// Discard
+    Discard,
 }
 
 impl ClassifyResult {
@@ -382,6 +391,7 @@ impl ClassifyResult {
             ClassifyResult::Reject => "REJECT",
             ClassifyResult::RejectWithMsg(_) => "REJECT_WITH_MSG",
             ClassifyResult::Quarantine => "QUARANTINE",
+            ClassifyResult::Discard => "DISCARD",
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,6 @@
 use mail_parser::{HeaderName, MessageParser, MessagePart};
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::error::Error;
-use std::fs::File;
-use std::io::{BufRead as _, BufReader};
 use std::net::IpAddr;
 use std::sync::Arc;
 
@@ -402,7 +399,6 @@ impl ClassifyResult {
 #[derive(Clone)]
 pub struct Config {
     full_mail_classifier: Option<Arc<dyn ClassifyEmail + Send + Sync>>,
-    fork_mode_enabled: bool,
 }
 
 impl Config {
@@ -425,7 +421,6 @@ impl Config {
 #[derive(Default)]
 pub struct ConfigBuilder {
     full_mail_classifier: Option<Arc<dyn ClassifyEmail + Send + Sync>>,
-    fork_mode_enabled: bool,
 }
 
 impl ConfigBuilder {
@@ -436,53 +431,10 @@ impl ConfigBuilder {
         self.full_mail_classifier = Some(classifier);
         self
     }
-    /// Enables fork mode support, allowing the `--fork` command-line option.
-    ///
-    /// Fork mode spawns child processes to handle milter connections. This can be
-    /// efficient but has important safety considerations that require explicit opt-in.
-    ///
-    /// # Safety Requirements
-    ///
-    /// Before enabling fork mode, ensure your application does **not** do any of the following
-    /// before calling [`cli::cli()`]:
-    ///
-    /// - **Use threads**: If the parent process has threads running, locks held by those
-    ///   threads will not be released in the forked children. This can cause deadlocks
-    ///   since the threads themselves are not copied—only the main thread continues in the
-    ///   child.
-    ///
-    /// - **Hold open connections**: Database connections, network sockets, or other stateful
-    ///   connections get inherited by child processes. When children exit, their drop
-    ///   implementations may send protocol shutdown messages or flush buffers, causing
-    ///   duplicate or corrupted communication with the remote endpoint.
-    ///
-    /// - **Use buffered I/O with autoflush**: Open files with buffered writers that flush
-    ///   on close can cause duplicate writes when both parent and children flush the same
-    ///   inherited buffer.
-    ///
-    /// Additionally, be aware that:
-    ///
-    /// - **Copy-on-write semantics apply**: Mutable data shared between classifier invocations
-    ///   will not actually be shared across forked children. Each child gets its own copy,
-    ///   so accumulated state (counters, caches) will not be visible to other children or
-    ///   the parent.
-    ///
-    /// - **Signal handlers are inherited**: Any custom signal handlers set before forking
-    ///   will be active in child processes, which may cause unexpected behavior.
-    ///
-    /// If your classifier is a pure function that only reads from immutable context data
-    /// loaded at startup, fork mode is safe and can provide good isolation between
-    /// connections.
-    #[deprecated(since = "6.0.0", note = "use threaded mode")]
-    pub fn enable_fork_mode(mut self) -> Self {
-        self.fork_mode_enabled = true;
-        self
-    }
     /// Builds the final [`Config`].
     pub fn build(self) -> Config {
         Config {
             full_mail_classifier: self.full_mail_classifier,
-            fork_mode_enabled: self.fork_mode_enabled,
         }
     }
 }
@@ -578,27 +530,6 @@ impl ConfigBuilder {
         self.full_mail_classifier = Some(Arc::new(classifier));
         self
     }
-}
-
-#[deprecated(since = "6.0.0", note = "trivial function should be hand-rolled")]
-pub fn read_array(filename: &str) -> Result<Vec<String>, Box<dyn Error>> {
-    let file = File::open(filename).map_err(|e| format!("{filename}: {e}"))?;
-    let reader = BufReader::new(file);
-    let mut out: Vec<String> = Vec::with_capacity(20);
-    for line in reader.lines() {
-        if let Some(s) = line?.split('#').next() {
-            let s = s.trim();
-            if !s.is_empty() {
-                out.push(s.into());
-            }
-        }
-    }
-    Ok(out)
-}
-
-#[deprecated(since = "6.0.0", note = "trivial function should be hand-rolled")]
-pub fn array_contains(haystack: &[String], needle: &str) -> bool {
-    haystack.iter().any(|s| s == needle)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- Add `MailInfo::discard()`
- Remove deprecated code and its dependencies:
  - All modes except of thread mode, because in reality this is the only mode we need. 
  - The `dump` command, which can better be done by an external utility like [emlhead](https://github.molgen.mpg.de/donald/emlhead)
- The `daemon` command now defaults to 64 threads.  
- Remove dependency on the systemd crate ( #5 )
- Minor documentation fixes

Fixes #5